### PR TITLE
#issue:4 replaced the revChatGPt function to V3

### DIFF
--- a/stackexplain/utilities/chatgpt.py
+++ b/stackexplain/utilities/chatgpt.py
@@ -3,7 +3,7 @@ import json
 import os.path as path
 
 # Third party
-from revChatGPT.revChatGPT import Chatbot
+from revChatGPT.V3 import Chatbot
 
 # Local
 from stackexplain.utilities.printers import prompt_user_for_credentials
@@ -51,4 +51,4 @@ def get_chatgpt_explanation(language, error_message):
     config = json.load(open(CONFIG_FP))
     query = construct_query(language, error_message)
     chatbot = Chatbot(config)
-    return chatbot.get_chat_response(query)["message"].strip()
+    return chatbot.ask(query)["message"].strip()


### PR DESCRIPTION
Updated Chatbot import and method call
This commit updates the import statement for the Chatbot class to reference the latest version in revChatGPT.V3 and changes the method call to use the updated method name "ask" instead of "get_chat_response". This should allow the "stackexplain" command to run successfully without encountering the "ModuleNotFoundError".



